### PR TITLE
Hide metric block in Hero section

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -21,6 +21,7 @@ export function Hero() {
           ))}
         </div>
 
+        {/* Metric block hidden while rethinking design
         <div className="grid grid-cols-2 gap-4 max-w-md mx-auto">
           {stats.map((stat) => (
             <div
@@ -34,6 +35,7 @@ export function Hero() {
             </div>
           ))}
         </div>
+        */}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- Comment out the stats grid in the Hero component while the design is being rethought
- Data and markup preserved for easy re-enable

https://claude.ai/code/session_01GUaN9P3revvdPcHtQiAEGU