### PR TITLE
Remove em-dash from Hero paragraph

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -12,7 +12,7 @@ export function Hero() {
         </p>
         <p className="text-base font-sans text-[#f4f4f4]/80 max-w-xl mx-auto mb-8">
           I&apos;ve spent 27 years building products with designers and
-          engineers — turning messy ideas into things people love using.
+          engineers, turning messy ideas into things people love using.
           Today I&apos;m focused on the intersection of marketplaces,
           automotive technology, and AI-assisted product development.
         </p>


### PR DESCRIPTION
Remove the em-dash from the first paragraph in the Hero component and rework the sentence to be grammatically correct using a comma instead.

Closes #7

Generated with [Claude Code](https://claude.ai/code)