### PR TITLE
Add blog page with navigation

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { BackgroundArt } from "@/components/BackgroundArt";
+import { Footer } from "@/components/Footer";
+
+export const metadata: Metadata = {
+  title: "Blog — Patrick Boggs",
+  description: "Thoughts on product, technology, and AI-accelerated development.",
+};
+
+export default function Blog() {
+  return (
+    <main className="min-h-screen relative">
+      <BackgroundArt />
+      <section className="relative z-10 py-16 px-6">
+        <div className="max-w-3xl mx-auto">
+          <h1 className="text-3xl md:text-4xl font-bold text-white mb-4">Blog</h1>
+          <p className="text-sm font-mono text-slate-400 tracking-wide mb-10">
+            Thoughts on product, technology, and AI-accelerated development.
+          </p>
+          <div className="rounded-xl border border-slate-700/30 bg-white/[0.04] p-8 text-center">
+            <p className="text-slate-400 font-mono text-sm">Posts coming soon.</p>
+          </div>
+        </div>
+      </section>
+      <Footer />
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Outfit, DM_Mono } from "next/font/google";
+import { Nav } from "@/components/Nav";
 import "./globals.css";
 
 const outfit = Outfit({
@@ -37,7 +38,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={`${outfit.variable} ${dmMono.variable}`}>
-      <body>{children}</body>
+      <body>
+        <Nav />
+        {children}
+      </body>
     </html>
   );
 }

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+const navLinks = [
+  { label: "Home", href: "/" },
+  { label: "Blog", href: "/blog" },
+];
+
+export function Nav() {
+  return (
+    <nav className="relative z-20 py-4 px-6 border-b border-slate-700/30">
+      <div className="max-w-3xl mx-auto flex items-center gap-6">
+        {navLinks.map((link) => (
+          <Link
+            key={link.label}
+            href={link.href}
+            className="text-sm font-mono text-slate-400 hover:text-cyan-400 transition-colors"
+          >
+            {link.label}
+          </Link>
+        ))}
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
Adds a /blog page and site-wide navigation component.

- New `Nav` component with Home and Blog links added to root layout
- New `/blog` page with placeholder content matching portfolio theme

Closes #9

Generated with [Claude Code](https://claude.ai/code)